### PR TITLE
refactor: add `ORY_KRATOS_URL ` as alternative to `ORY_SDK_URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ export default createApiHandler({
 })
 ```
 
-You need to set the environment variable `ORY_KRATOS_URL` to your
-[Ory Cloud Project SDK URL](https://www.ory.sh/docs/concepts/services-api). For
-a list of available options head over to
+You need to set the environment variable `ORY_SDK_URL` or `ORY_KRATOS_URL` to
+your [Ory Cloud Project SDK URL](https://www.ory.sh/docs/concepts/services-api).
+For a list of available options head over to
 [`src/nextjs/index.ts`](src/next-edge/index.ts).
 
 ## SDK Helpers
@@ -52,14 +52,14 @@ import {
   isUiNodeImageAttributes,
   isUiNodeInputAttributes,
   isUiNodeScriptAttributes,
-  isUiNodeTextAttributes,
+  isUiNodeTextAttributes
   // ...
 } from '@ory/integrations/ui'
 
 // ...
 
 if (isUiNodeImageAttributes(node.attributes)) {
-  console.log("it is an image: ", node.attributes.src)
+  console.log('it is an image: ', node.attributes.src)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default createApiHandler({
 })
 ```
 
-You need to set the environment variable `ORY_SDK_URL` to your
+You need to set the environment variable `ORY_KRATOS_URL` to your
 [Ory Cloud Project SDK URL](https://www.ory.sh/docs/concepts/services-api). For
 a list of available options head over to
 [`src/nextjs/index.ts`](src/next-edge/index.ts).
@@ -59,7 +59,7 @@ import {
 // ...
 
 if (isUiNodeImageAttributes(node.attributes)) {
-  console.log("it is an image": node.attributes.src)
+  console.log("it is an image: ", node.attributes.src)
 }
 ```
 

--- a/src/next-edge/index.ts
+++ b/src/next-edge/index.ts
@@ -20,7 +20,7 @@ const encode = (v: string) => v
 export interface CreateApiHandlerOptions {
   /**
    * If set overrides the API Base URL. Usually, this URL
-   * is taken from the ORY_SDK_URL environment variable.
+   * is taken from the ORY_KRATOS_URL environment variable.
    *
    * If you don't have a project you can use the playground project SDK URL:
    *
@@ -52,14 +52,14 @@ export interface CreateApiHandlerOptions {
 /**
  * Creates a NextJS / Vercel API Handler
  *
- * For this handler to work, please set the environment variable `ORY_SDK_URL`.
+ * For this handler to work, please set the environment variable `ORY_KRATOS_URL`.
  */
 export function createApiHandler(options: CreateApiHandlerOptions) {
   let baseUrl = options.fallbackToPlayground
     ? 'https://playground.projects.oryapis.com/'
     : ''
-  if (process.env.ORY_SDK_URL) {
-    baseUrl = process.env.ORY_SDK_URL
+  if (process.env.ORY_KRATOS_URL) {
+    baseUrl = process.env.ORY_KRATOS_URL
   }
 
   if (options.apiBaseUrlOverride) {

--- a/src/next-edge/index.ts
+++ b/src/next-edge/index.ts
@@ -58,8 +58,17 @@ export function createApiHandler(options: CreateApiHandlerOptions) {
   let baseUrl = options.fallbackToPlayground
     ? 'https://playground.projects.oryapis.com/'
     : ''
+
+  if (process.env.ORY_SDK_URL) {
+    baseUrl = process.env.ORY_SDK_URL
+  }
+
   if (process.env.ORY_KRATOS_URL) {
     baseUrl = process.env.ORY_KRATOS_URL
+  }
+
+  if (process.env.ORY_SDK_URL && process.env.ORY_KRATOS_URL) {
+    throw new Error('Only one of ORY_SDK_URL or ORY_KRATOS_URL can be set.')
   }
 
   if (options.apiBaseUrlOverride) {


### PR DESCRIPTION
BREAKING CHANGE: Rename env var `ORY_SDK_URL` to `ORY_KRATOS_URL`:

```patch
- export ORY_SDK_URL=https://playground.projects.oryapis.com/
+ export ORY_KRATOS_URL=https://playground.projects.oryapis.com/
```