### PR TITLE
fix: path name for ory integration next edge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, add create a file at `<your-nextjs-app>/api/.ory/[...paths.ts]` with the
 following contents:
 
 ```typescript
-import { config, createApiHandler } from '@ory/integrations/next/edge'
+import { config, createApiHandler } from '@ory/integrations/next-edge'
 
 export { config }
 


### PR DESCRIPTION
Changed the path in the readme from '@ory/integrations/next/edge' to  '@ory/integrations/next-edge'

Thank You.