### PR TITLE
chore: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Ory GmbH",
   "prettier": "ory-prettier-styles",
   "license": "Apache-2.0",
+  "repository": "https://github.com/ory/integrations",
   "config": {
     "prettierTarget": "**/*.{tsx,ts,json,md,js,css}"
   },


### PR DESCRIPTION
This makes it easier to get to the source code from https://npmjs.com/@ory/integrations, and allows tools like renovatebot to find the changelog