### PR TITLE
feat: use TLD per default for cookie domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "v0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ory/client": ">=0.0.1-alpha.21",
+        "@ory/client": ">=0.0.1-alpha.49",
         "cookie": "^0.4.1",
         "istextorbinary": "^6.0.0",
         "next": ">=12.0.10",
@@ -29,6 +29,7 @@
         "@types/request": "^2.48.7",
         "@types/set-cookie-parser": "^2.4.1",
         "@types/supertest": "^2.0.11",
+        "@types/tldjs": "^2.3.1",
         "babel-jest": "^27.2.0",
         "esbuild": "^0.12.28",
         "express": "^4.17.1",
@@ -37,6 +38,7 @@
         "rollup-plugin-dts": "^4.0.0",
         "rollup-plugin-esbuild": "^4.5.0",
         "supertest": "^6.1.6",
+        "tldjs": "^2.3.1",
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
@@ -2925,11 +2927,11 @@
       }
     },
     "node_modules/@ory/client": {
-      "version": "0.0.1-alpha.21",
-      "resolved": "https://registry.npmjs.org/@ory/client/-/client-0.0.1-alpha.21.tgz",
-      "integrity": "sha512-SqjjcZ4uV767AGLzOEnSVGe0SSGMubg1NL33NEqqDKA96Xr08UUg+RlbrKpncHi8hznYYHI9iwlRskHJA2/xkQ==",
+      "version": "0.0.1-alpha.105",
+      "resolved": "https://registry.npmjs.org/@ory/client/-/client-0.0.1-alpha.105.tgz",
+      "integrity": "sha512-VwpKQTk+gBfE60hC12qg9YsXkxZ0f9KIqdePqgKn6FDv8RayIlrDp/TpWMQG5fR/XvmEn6rgEEEVo52dp7AcOw==",
       "dependencies": {
-        "axios": "^0.21.1"
+        "axios": "^0.21.4"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -3215,6 +3217,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/tldjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-2.3.1.tgz",
+      "integrity": "sha512-BQR04zLE0ve2eNrqxXw/Qp/f6LxvNrj/4A8ZgdQi3SzbBqxFhleI7N4DS/mSjDnODrUaEGgoWg4grAZR1kVj8w==",
+      "dev": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.1",
@@ -7922,6 +7930,12 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
     "node_modules/qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -8777,6 +8791,19 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.1.tgz",
+      "integrity": "sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11347,11 +11374,11 @@
       "optional": true
     },
     "@ory/client": {
-      "version": "0.0.1-alpha.21",
-      "resolved": "https://registry.npmjs.org/@ory/client/-/client-0.0.1-alpha.21.tgz",
-      "integrity": "sha512-SqjjcZ4uV767AGLzOEnSVGe0SSGMubg1NL33NEqqDKA96Xr08UUg+RlbrKpncHi8hznYYHI9iwlRskHJA2/xkQ==",
+      "version": "0.0.1-alpha.105",
+      "resolved": "https://registry.npmjs.org/@ory/client/-/client-0.0.1-alpha.105.tgz",
+      "integrity": "sha512-VwpKQTk+gBfE60hC12qg9YsXkxZ0f9KIqdePqgKn6FDv8RayIlrDp/TpWMQG5fR/XvmEn6rgEEEVo52dp7AcOw==",
       "requires": {
-        "axios": "^0.21.1"
+        "axios": "^0.21.4"
       }
     },
     "@rollup/pluginutils": {
@@ -11630,6 +11657,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/tldjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-2.3.1.tgz",
+      "integrity": "sha512-BQR04zLE0ve2eNrqxXw/Qp/f6LxvNrj/4A8ZgdQi3SzbBqxFhleI7N4DS/mSjDnODrUaEGgoWg4grAZR1kVj8w==",
+      "dev": true
     },
     "@types/tough-cookie": {
       "version": "4.0.1",
@@ -15188,6 +15221,12 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -15829,6 +15868,15 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tldjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.1.tgz",
+      "integrity": "sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/request": "^2.48.7",
     "@types/set-cookie-parser": "^2.4.1",
     "@types/supertest": "^2.0.11",
+    "@types/tldjs": "^2.3.1",
     "babel-jest": "^27.2.0",
     "esbuild": "^0.12.28",
     "express": "^4.17.1",
@@ -35,6 +36,7 @@
     "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-esbuild": "^4.5.0",
     "supertest": "^6.1.6",
+    "tldjs": "^2.3.1",
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
@@ -42,7 +44,7 @@
     "next": ">=12.0.10"
   },
   "dependencies": {
-    "@ory/client": ">=0.0.1-alpha.21",
+    "@ory/client": ">=0.0.1-alpha.49",
     "cookie": "^0.4.1",
     "istextorbinary": "^6.0.0",
     "next": ">=12.0.10",


### PR DESCRIPTION
This PR changes the behavior of the cookie detection mechanism to automatically set the cookie domain to the TLD of the request. To get the old behavior, set `dontUseTldForCookieDomain` to `true`.

Closes https://github.com/ory/integrations/issues/20