### PR TITLE
docs: example for vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,23 @@ This repository contains integrations for connecting with Ory Cloud.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [NextJS / Vercel](#nextjs--vercel)
+- [NextJS](#nextjs)
+- [Vercel](#vercel)
+- [SDK Helpers](#sdk-helpers)
+  - [Type Guards](#type-guards)
+  - [UI Node Helpers](#ui-node-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## NextJS / Vercel
+## NextJS
 
-To connect a NextJS (optionally deployed via Vercel) with Ory, do the following
-in your NextJS App:
+To connect a NextJS app with Ory, do the following in your NextJS App:
 
 ```
 $ npm i --save @ory/integrations
 ```
 
-Then, add create a file at `<your-nextjs-app>/api/.ory/[...paths.ts]` with the
+Then create a file at `<your-nextjs-app>/api/.ory/[...paths.ts]` with the
 following contents:
 
 ```typescript
@@ -37,6 +40,42 @@ You need to set the environment variable `ORY_SDK_URL` to your
 [Ory Cloud Project SDK URL](https://www.ory.sh/docs/concepts/services-api). For
 a list of available options head over to
 [`src/nextjs/index.ts`](src/next-edge/index.ts).
+
+## Vercel
+
+To connect a non NextJS vercel app, do the following in your vercel app:
+
+```
+$ npm i --save @ory/integrations
+```
+
+Then create a file at `<your-vercel-app>/api/oryproxy.js` with the following
+contents:
+
+```javascript
+import { config, createApiHandler } from '@ory/integrations/next-edge'
+
+export { config }
+
+const ah = createApiHandler({
+  /* ... */
+})
+const apiHandlerWrapper = (req, res) => {
+  req.query.paths = req.url.replace(/^\/api\/.ory\//, '').split('?')[0]
+  ah(req, res)
+}
+export default apiHandlerWrapper
+```
+
+Then add the following contents to `<your-vercel-app>/vercel.json`:
+
+```
+{
+    "rewrites": [
+        { "source": "/api/.ory/:match*", "destination": "/api/oryproxy" }
+    ]
+}
+```
 
 ## SDK Helpers
 


### PR DESCRIPTION
This is kindof a shoehorn implementation.  
But it does work well, and thats how we have done it currently.  

When you  make this integration support netlify aswell, I guess there will be a lot of refactoring, so I dont see any point in doing huge refactoring just to fit vercel, which already kindof fits.  

