### PR TITLE
Fix NextJS API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To connect a NextJS app with Ory, do the following in your NextJS App:
 $ npm i --save @ory/integrations
 ```
 
-Then create a file at `<your-nextjs-app>/api/.ory/[...paths.ts]` with the
+Then create a file at `<your-nextjs-app>/api/.ory/[...paths].ts` with the
 following contents:
 
 ```typescript


### PR DESCRIPTION
The closing bracket for the API file path needed to come before the extension. 
Super tiny fix 🙃 