### PR TITLE
fix(deps): update minimist to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7442,9 +7442,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -14873,9 +14873,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {


### PR DESCRIPTION
This PR fixes npm audit report using `npm audit fix`.

```bash
# npm audit report                                                                                       
                                                                                                         
minimist  <1.2.6                                                                                         
Severity: critical                                                                                                                                                                                                 
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h                      
fix available via `npm audit fix`                                                                                                                                                                                  
node_modules/minimist                                                                                    
                                                    
1 critical severity vulnerability                   
                                                    
To address all issues, run: 
  npm audit fix 
```

