### PR TITLE
chore: bump to @ory/client v1.1.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-typescript": "^7.15.0",
-        "@ory/client": "^1.1.4",
+        "@ory/client": "^1.1.39",
         "@types/cookie": "^0.4.1",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.1",
@@ -42,7 +42,7 @@
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
-        "@ory/client": "^1.1.4",
+        "@ory/client": "1.1.39",
         "next": ">=12.0.10"
       }
     },
@@ -2586,9 +2586,9 @@
       }
     },
     "node_modules/@ory/client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ory/client/-/client-1.1.4.tgz",
-      "integrity": "sha512-NEM9XwH3HivMQBFAn1YRx91AAFK5KRQgM2XVTLZcyWsOWKxNwlAPxZasBq5OODac8j1aRMfcb6/VyK3K5ikzFg==",
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/@ory/client/-/client-1.1.39.tgz",
+      "integrity": "sha512-7giFPOvVOVe/mouTQNmuTc86GCJCqMw8hU8lQj+t79E6CZ9MiKZXhXqXCdJldSHL54gV+I+xTMho0ObQuDl0+A==",
       "dev": true,
       "dependencies": {
         "axios": "^0.21.4"
@@ -10758,9 +10758,9 @@
       "optional": true
     },
     "@ory/client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ory/client/-/client-1.1.4.tgz",
-      "integrity": "sha512-NEM9XwH3HivMQBFAn1YRx91AAFK5KRQgM2XVTLZcyWsOWKxNwlAPxZasBq5OODac8j1aRMfcb6/VyK3K5ikzFg==",
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/@ory/client/-/client-1.1.39.tgz",
+      "integrity": "sha512-7giFPOvVOVe/mouTQNmuTc86GCJCqMw8hU8lQj+t79E6CZ9MiKZXhXqXCdJldSHL54gV+I+xTMho0ObQuDl0+A==",
       "dev": true,
       "requires": {
         "axios": "^0.21.4"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-typescript": "^7.15.0",
+    "@ory/client": "^1.1.39",
     "@types/cookie": "^0.4.1",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.1",
@@ -35,22 +36,21 @@
     "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-esbuild": "^4.5.0",
     "supertest": "^6.1.6",
-    "typescript": "^4.4.3",
-    "@ory/client": "^1.1.4"
+    "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "@ory/client": "^1.1.4",
+    "@ory/client": "1.1.39",
     "next": ">=12.0.10"
   },
   "dependencies": {
+    "@types/tldjs": "^2.3.1",
     "cookie": "^0.4.1",
     "istextorbinary": "^6.0.0",
     "next": ">=12.0.10",
-    "@types/tldjs": "^2.3.1",
-    "tldjs": "^2.3.1",
     "ory-prettier-styles": "^1.3.0",
     "prettier": "^2.3.2",
     "request": "^2.88.2",
-    "set-cookie-parser": "^2.4.8"
+    "set-cookie-parser": "^2.4.8",
+    "tldjs": "^2.3.1"
   }
 }


### PR DESCRIPTION
Update the `@ory/client` to `v1.1.39`.