### PR TITLE
fix: peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
-        "@ory/client": "1.1.39",
+        "@ory/client": ">=1.1.39",
         "next": ">=12.0.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "@ory/client": "1.1.39",
+    "@ory/client": ">=1.1.39",
     "next": ">=12.0.10"
   },
   "dependencies": {


### PR DESCRIPTION
Peer dependencies of `@ory/client` should be based on any version equal to and greater than v1.1.39