### PR TITLE
chore(actions): upgrade release workflow to use node v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
       - run: npm ci
       - run: npm run format:check
       - run: npm run test


### PR DESCRIPTION
As per #62, this should fix the release failure discussed in #51.