### PR TITLE
fix: prettier as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "cookie": "0.6.0",
         "istextorbinary": "9.5.0",
         "next": ">=12.0.10",
-        "ory-prettier-styles": "1.3.0",
-        "prettier": "3.2.5",
         "set-cookie-parser": "2.6.0",
         "tldjs": "2.3.1"
       },
@@ -33,6 +31,8 @@
         "esbuild": "0.20.1",
         "express": "4.18.2",
         "jest": "29.7.0",
+        "ory-prettier-styles": "1.3.0",
+        "prettier": "3.2.5",
         "rollup": "4.12.0",
         "rollup-plugin-dts": "6.1.0",
         "rollup-plugin-esbuild": "6.1.1",
@@ -7432,7 +7432,8 @@
     "node_modules/ory-prettier-styles": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.3.0.tgz",
-      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug=="
+      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug==",
+      "dev": true
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -7605,6 +7606,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test": "jest --forceExit"
   },
   "devDependencies": {
+    "ory-prettier-styles": "1.3.0",
+    "prettier": "3.2.5",
     "@babel/core": "7.23.9",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-typescript": "7.23.3",
@@ -47,8 +49,6 @@
     "cookie": "0.6.0",
     "istextorbinary": "9.5.0",
     "next": ">=12.0.10",
-    "ory-prettier-styles": "1.3.0",
-    "prettier": "3.2.5",
     "set-cookie-parser": "2.6.0",
     "tldjs": "2.3.1"
   }


### PR DESCRIPTION
If its not devDependencies, it propagates up to our projects when we install this dependency.
I Think if its devDependency, it does not.