### PR TITLE
Support application/x-www-form-urlencoded requests

### DIFF
--- a/src/next-edge/index.ts
+++ b/src/next-edge/index.ts
@@ -112,7 +112,9 @@ export function createApiHandler(options: CreateApiHandlerOptions) {
       headers,
       body:
         req.method !== "GET" && req.method !== "HEAD"
-          ? JSON.stringify(req.body)
+          ? headers.get("content-type").includes("json")
+            ? JSON.stringify(req.body)
+            : new URLSearchParams(req.body)
           : null,
       redirect: "manual",
     })


### PR DESCRIPTION
Currently it  only supports json bodies.
Which dont work with kratos-selfservice-ui-node.
Its unfortunate that we can't just pass on the body,  but have to encode it to the correct type.
But with this change, I can login using kratos-selfserivec-ui-node, which uses `application/x-www-form-urlencoded`